### PR TITLE
improving versioning out toString

### DIFF
--- a/source/optional/optional.d
+++ b/source/optional/optional.d
@@ -266,21 +266,19 @@ struct Optional(T) {
         }
     }
 
-    version (D_BetterC) {} else {
-        /// Converts value to string
-        string toString() const {
-            import std.conv: to; import std.traits;
-            if (empty) {
-                return "[]";
-            }
-            // Cast to unqual if we can copy so writing it out does the right thing.
-            static if (isCopyable!T && __traits(compiles, cast(Unqual!T)this._value)) {
-                immutable str = to!string(cast(Unqual!T)this._value);
-            } else {
-                immutable str = to!string(this._value);
-            }
-            return "[" ~ str ~ "]";
+    /// Converts value to string
+    string toString()() const {
+        import std.conv: to; import std.traits;
+        if (empty) {
+            return "[]";
         }
+        // Cast to unqual if we can copy so writing it out does the right thing.
+        static if (isCopyable!T && __traits(compiles, cast(Unqual!T)this._value)) {
+          immutable str = to!string(cast(Unqual!T)this._value);
+        } else {
+          immutable str = to!string(this._value);
+        }
+        return "[" ~ str ~ "]";
     }
 
     static if (__traits(compiles, {


### PR DESCRIPTION
I had some issues with the toString function with a struct T that has a non-copyable member. Basically `std.format` doesn't like it.

By making toString a template it is betterC compatible AND the toString method isn't instantiated when it is not used. Plus it looks better as well.