### PR TITLE
add library config

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,6 +12,10 @@
     },
     "configurations": [
         {
+            "name": "library",
+            "targetType": "library"
+        },
+        {
             "name": "unittest",
             "importPaths": [
                 "./tests"


### PR DESCRIPTION
Right now having `optional` as a dub dependency causes it to build the `unittest` configuration.

This is because the `unittest` config is the first in the `dub.json`, and when you don't specify a configuration for a dependency dub just picks the first.

If I change my compiler's configuration file (`dmd.conf` or `ldc2.conf`) and add `-betterC` (because I want to enforce `betterC` on my dependencies), the build fails because the `./tests` contains files which are not `betterC` compatible.

By adding this `library` configuration the `./tests` files are no longer included in the compile.