### PR TITLE
Fix inout references and optional chain matching

### DIFF
--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -21,43 +21,47 @@ public template match(handlers...) if (handlers.length == 2) {
 	        static if (is(typeof(handlers[0](opt.front)))) {
 	            alias someHandler = handlers[0];
 	            alias noHandler = handlers[1];
+				return doMatch!(someHandler, noHandler, O, T)(opt);
 	        } else static if (is(typeof(handlers[0]()))) {
 	            alias someHandler = handlers[1];
 	            alias noHandler = handlers[0];
+				return doMatch!(someHandler, noHandler, O, T)(opt);
 	        } else {
 				// One of these two is causing a compile error.
 				// Let's call them so the compiler can show a proper error warning.
 				failOnCompileError!(handlers[0], T);
 				failOnCompileError!(handlers[1], T);
 			}
-
-	        alias SomeHandlerReturn = typeof(someHandler(T.init));
-	        alias NoHandlerReturn = typeof(noHandler());
-	        enum isVoidReturn = is(typeof(someHandler(T.init)) == void) || is(typeof(noHandler()) == void);
-
-	        static assert(
-	            is(SomeHandlerReturn == NoHandlerReturn) || isVoidReturn,
-	            "Expected two handlers to return same type, found type '" ~ SomeHandlerReturn.stringof ~ "' and type '" ~ NoHandlerReturn.stringof ~ "'",
-	        );
-
-	        if (opt.empty) {
-	            static if (isVoidReturn) {
-	                noHandler();
-	            } else {
-	                return noHandler();
-	            }
-	        } else {
-	            static if (isVoidReturn) {
-	                someHandler(opt.front);
-	            } else {
-	                return someHandler(opt.front);
-	            }
-	        }
 		} else static if (is(typeof(opt.value) == Optional!T, T)) {
 			return opt.valueMatch!handlers;
 		} else {
 			pragma(msg, "Type of: " ~ typeof(opt.value).stringof);
 			static assert(0, "Cannot match!() on a " ~ O.stringof);
+		}
+	}
+}
+
+private auto doMatch(alias someHandler, alias noHandler, O, T)(ref auto O opt) {
+	alias SomeHandlerReturn = typeof(someHandler(T.init));
+	alias NoHandlerReturn = typeof(noHandler());
+	enum isVoidReturn = is(typeof(someHandler(T.init)) == void) || is(typeof(noHandler()) == void);
+
+	static assert(
+		is(SomeHandlerReturn == NoHandlerReturn) || isVoidReturn,
+		"Expected two handlers to return same type, found type '" ~ SomeHandlerReturn.stringof ~ "' and type '" ~ NoHandlerReturn.stringof ~ "'",
+	);
+
+	if (opt.empty) {
+		static if (isVoidReturn) {
+			noHandler();
+		} else {
+			return noHandler();
+		}
+	} else {
+		static if (isVoidReturn) {
+			someHandler(opt.front);
+		} else {
+			return someHandler(opt.front);
 		}
 	}
 }
@@ -75,14 +79,8 @@ private template valueMatch(handlers...) if (handlers.length == 2) {
 Prints out the correct compile error if the handler cannot be compiled.
 */
 private void failOnCompileError(alias handler, T)() {
-	static if (!is(typeof(handlers[0](T.init))) || !is(typeof(handlers[1](T.init)))) {
+	static if (!is(typeof(handler(T.init))) && !is(typeof(handler()))) {
 		cast(void) handler(T.init);
-		static assert(true,
-			"\n============================================================\n" ~
-			"The above delegate or function pointer has a compiler error.\n" ~
-			"Fix it before fixing the errors below.\n" ~
-			"============================================================\n"
-		);
 	}
 }
 

--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -34,7 +34,6 @@ public template match(handlers...) if (handlers.length == 2) {
 		} else static if (is(typeof(opt.value) == Optional!T, T)) {
 			return opt.valueMatch!handlers;
 		} else {
-			pragma(msg, "Type of: " ~ typeof(opt.value).stringof);
 			static assert(0, "Cannot match!() on a " ~ O.stringof);
 		}
 	}

--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -15,7 +15,7 @@ import optional.optional;
         handlers = 2 predicates, one that takes the underlying optional type and another that names nothing
 */
 public template match(handlers...) if (handlers.length == 2) {
-	auto match(O)(O opt) {
+	auto match(O)(auto ref O opt) {
 		static if (is(O == Optional!T, T)) {
 	        static if (is(typeof(handlers[0](opt.front)))) {
 	            alias someHandler = handlers[0];
@@ -57,7 +57,7 @@ public template match(handlers...) if (handlers.length == 2) {
 }
 
 private template valueMatch(handlers...) if (handlers.length == 2) {
-	auto valueMatch(O)(ref O opt) {
+	auto valueMatch(O)(auto ref O opt) {
 		return opt.value.match!handlers;
 	}
 }

--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -17,17 +17,23 @@ import optional.optional;
 public template match(handlers...) if (handlers.length == 2) {
 	auto match(O)(auto ref O opt) {
 		static if (is(O == Optional!T, T)) {
+			pragma(msg, typeof(handlers));
 	        static if (is(typeof(handlers[0](opt.front)))) {
 	            alias someHandler = handlers[0];
 	            alias noHandler = handlers[1];
-	        } else {
+	        } else static if (is(typeof(handlers[0]()))) {
 	            alias someHandler = handlers[1];
 	            alias noHandler = handlers[0];
-	        }
+	        } else {
+				// One of these two is causing a compile error.
+				// Let's call them so the compiler can show a proper error warning.
+				failOnCompileError!(handlers[0], T);
+				failOnCompileError!(handlers[1], T);
+			}
 
-	        alias SomeHandlerReturn = typeof(someHandler(opt.front));
+	        alias SomeHandlerReturn = typeof(someHandler(T.init));
 	        alias NoHandlerReturn = typeof(noHandler());
-	        enum isVoidReturn = is(SomeHandlerReturn == void) || is(NoHandlerReturn == void);
+	        enum isVoidReturn = is(typeof(someHandler(T.init)) == void) || is(typeof(noHandler()) == void);
 
 	        static assert(
 	            is(SomeHandlerReturn == NoHandlerReturn) || isVoidReturn,
@@ -56,9 +62,27 @@ public template match(handlers...) if (handlers.length == 2) {
 	}
 }
 
+/**
+Performs a match on the `value` property of a variable.
+*/
 private template valueMatch(handlers...) if (handlers.length == 2) {
 	auto valueMatch(O)(auto ref O opt) {
 		return opt.value.match!handlers;
+	}
+}
+
+/**
+Prints out the correct compile error if the handler cannot be compiled.
+*/
+private void failOnCompileError(alias handler, T)() {
+	static if (!is(typeof(handlers[0](T.init))) || !is(typeof(handlers[1](T.init)))) {
+		cast(void) handler(T.init);
+		static assert(true,
+			"\n============================================================\n" ~
+			"The above delegate or function pointer has a compiler error.\n" ~
+			"Fix it before fixing the errors below.\n" ~
+			"============================================================\n"
+		);
 	}
 }
 

--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -17,7 +17,6 @@ import optional.optional;
 public template match(handlers...) if (handlers.length == 2) {
 	auto match(O)(auto ref O opt) {
 		static if (is(O == Optional!T, T)) {
-			pragma(msg, typeof(handlers));
 	        static if (is(typeof(handlers[0](opt.front)))) {
 	            alias someHandler = handlers[0];
 	            alias noHandler = handlers[1];

--- a/tests/match.d
+++ b/tests/match.d
@@ -15,7 +15,7 @@ import optional;
     }
 }
 
-@("shoudl work with void return")
+@("Should work with void return")
 unittest {
     int i = 0;
     int j = 0;
@@ -42,4 +42,20 @@ unittest {
     assert(j == 3);
 
 
+}
+
+@("Should work with mutable references")
+unittest {
+	static class MyClass {
+		int x = 0;
+	}
+
+	auto obj = some(new MyClass);
+	int val;
+	obj.match!(
+		(obj) => val = (obj.x = 1),
+		() => val = 0,
+	);
+
+	assert(val == 1);
 }

--- a/tests/oc.d
+++ b/tests/oc.d
@@ -285,3 +285,21 @@ unittest {
     assert(oc(a).i == some(3));
     assert(oc(b).i == no!int);
 }
+
+@("Result of optional chain must be pattern matchable")
+@safe @nogc unittest {
+	static struct TypeA {
+		string x;
+	}
+	static struct TypeB {
+		auto getValue() {
+			return TypeA("yes");
+		}
+	}
+	auto b = some(TypeB());
+	const result = oc(b).getValue().match!(
+		(a) => a.x,
+		() => "no"
+	);
+	assert(result == "yes");
+}


### PR DESCRIPTION
This PR fixes two distinct bugs:
- When an object of type `T` is passed to a match, the `some`-handler receives a type of `inout(T)` instead of `T`. This makes it impossible for the matcher to pass the value on to another functions.
- Calling `oc(...).match!(...)` throws an error. This is possibly related to the fix for the first issue.

This PR changes the way the `match` function checks that the type of its function arguments is correct.

Unit tests were added for both bugs.