### PR TITLE
Allow match to operate on nested optionals

### DIFF
--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -80,12 +80,6 @@ private template valueMatch(handlers...) if (handlers.length == 2) {
 	}
 }
 
-private template proxyMatch(handlers...) if (handlers.length == 2) {
-	auto proxyMatch(O)(auto ref O opt) {
-		return opt.match!handlers;
-	}
-}
-
 /**
 Prints out the correct compile error if the handler cannot be compiled.
 */

--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -16,7 +16,13 @@ import optional.optional;
 */
 public template match(handlers...) if (handlers.length == 2) {
 	auto match(O)(auto ref O opt) {
-		static if (is(O == Optional!T, T)) {
+		static if (is(O == Optional!(Optional!T), T)) {
+			if (opt.empty) {
+				return no!T().match!handlers;
+			} else {
+				return opt.front.match!handlers;
+			}
+		} else static if (is(O == Optional!T, T)) {
 	        static if (is(typeof(handlers[0](opt.front)))) {
 	            alias someHandler = handlers[0];
 	            alias noHandler = handlers[1];
@@ -71,6 +77,12 @@ Performs a match on the `value` property of a variable.
 private template valueMatch(handlers...) if (handlers.length == 2) {
 	auto valueMatch(O)(auto ref O opt) {
 		return opt.value.match!handlers;
+	}
+}
+
+private template proxyMatch(handlers...) if (handlers.length == 2) {
+	auto proxyMatch(O)(auto ref O opt) {
+		return opt.match!handlers;
 	}
 }
 

--- a/tests/match.d
+++ b/tests/match.d
@@ -59,3 +59,23 @@ unittest {
 
 	assert(val == 1);
 }
+
+@("Some of some is present")
+@safe @nogc unittest {
+	auto a = some(some(5));
+	const result = a.match!(
+		b => b + 1,
+		() => 0
+	);
+	assert(result == 6);
+}
+
+@("Some of no is not present")
+@safe @nogc unittest {
+	auto a = some(no!int);
+	const result = a.match!(
+		a => "yes",
+		() => "no"
+	);
+	assert(result == "no");
+}


### PR DESCRIPTION
This change allows `match` to operate on an `Optional!(Optional!T)` as if it was just an `Optional!T`.
If any of the `Optional`s are empty, the empty handler will be executed.
The some handler will only be executed if all `Optional`s have a value.