### PR TITLE
Static assert in or(): Refer to or, not frontOr

### DIFF
--- a/source/optional/or.d
+++ b/source/optional/or.d
@@ -178,7 +178,7 @@ auto or(alias elsePred, T)(auto ref T value) {
         return ret!ElseType(value);
     } else {
         static assert(0,
-            "Unable to call frontOr on type " ~ T.stringof ~ ". It has to either be an input range,"
+            "Unable to call or on type " ~ T.stringof ~ ". It has to either be an input range,"
             ~ " a null testable type, a Nullable!T, or an Optional!T"
         );
     }


### PR DESCRIPTION
Now, the static assert message in or() correctly says that we tried to instantiate or(), not frontOr().