### PR TITLE
Fix #61: Put 'auto ref' storage classes adjacent

### DIFF
--- a/source/optional/match.d
+++ b/source/optional/match.d
@@ -43,7 +43,7 @@ public template match(handlers...) if (handlers.length == 2) {
 	}
 }
 
-private auto doMatch(alias someHandler, alias noHandler, T, O)(ref auto O opt) {
+private auto doMatch(alias someHandler, alias noHandler, T, O)(auto ref O opt) {
 	alias SomeHandlerReturn = typeof(someHandler(T.init));
 	alias NoHandlerReturn = typeof(noHandler());
 	enum isVoidReturn = is(typeof(someHandler(T.init)) == void) || is(typeof(noHandler()) == void);

--- a/source/optional/optional.d
+++ b/source/optional/optional.d
@@ -348,7 +348,7 @@ auto toOptional(R)(auto ref R range) if (from.std.range.isInputRange!R) {
 }
 
 /// Ditto
-auto toOptional(T)(auto inout ref Nullable!T nullable) {
+auto toOptional(T)(auto ref inout Nullable!T nullable) {
     if (nullable.isNull) {
         return inout Optional!T();
     } else {


### PR DESCRIPTION
Before, DMD 2.111.0 produced twice the following deprecation warning: "Deprecation: `auto` and `ref` storage classes should be adjacent"

https://dlang.org/changelog/2.111.0.html#dmd.auto-ref-put-adjacent

Now, package optional builds warning-free and deprecation-free with the recently released DMD 2.111.0.